### PR TITLE
Minor improvements regarding variables and resources discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ module "bastion" {
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| vpc_id | The VPC where bastion is going to be deployed | string |  | yes |
+| vpc_name | The VPC where bastion is going to be deployed | string |  | yes |
 | route53_zone | The DNS hostzone where bastion is going to be created, usually is going to be something like bastion.$clusterName.cloud-platform.service.justice.gov.uk. | string | | yes |
 | key_name | The key_pair name to be used in the bastion instance | string | | yes |
 

--- a/variables.tf
+++ b/variables.tf
@@ -4,22 +4,12 @@ variable "route53_zone" {
   type        = string
 }
 
-variable "vpc_id" {
-  description = "The vpc_id where the security groups and bastions are going to be created"
+variable "vpc_name" {
+  description = "The vpc_name where the security groups and bastions are going to be created"
   type        = string
 }
 
 variable "key_name" {
   description = "The key_pair name to be used in the bastion instance"
   type        = string
-}
-
-variable "public_subnets" {
-  description = "The public subnets IDs where bastion ASG will use"
-  type        = list
-}
-
-variable "bastion_depends_on" {
-  type    = any
-  default = null
 }


### PR DESCRIPTION

- Deleted unused variables (`bastion_depends_on `)
- Removed `public_subnets` variables: if you have VPC name/id they can be obtained using data resources as you can see in the `main.tf`
- Replaced `vpc_id` variable with `vpc_name`. Always easier to identify names instead of random characters.
