### PR TITLE
Store values in the same order as returned

### DIFF
--- a/bin/update-authorized-keys.rb
+++ b/bin/update-authorized-keys.rb
@@ -29,7 +29,7 @@ BRANCH = SecureRandom.alphanumeric
 def main
   authorized_keys = build_authorized_keys
 
-  content_sha, encoded_authorized_keys = compare_with_existing_keys(authorized_keys)
+  encoded_authorized_keys, content_sha  = compare_with_existing_keys(authorized_keys)
 
   if encoded_authorized_keys.nil?
     puts "No new publicKeys to raise PR"


### PR DESCRIPTION
The values are stored in the different order than it is returned which lead to a bug in getting the SHA and encoded keys.