### PR TITLE
Parse json before fetching the value with hash key

### DIFF
--- a/bin/update-authorized-keys.rb
+++ b/bin/update-authorized-keys.rb
@@ -35,7 +35,8 @@ def main
     puts "No new publicKeys to raise PR"
   else
     create_new_branch_commit(content_sha, encoded_authorized_keys)
-    json = create_pull_request
+    data = create_pull_request
+    json = JSON.parse(data)
     puts "publicKeys of Webops team members to access bastion node has changed. Check the PR: #{json[:url]}"
     exit 1
   end


### PR DESCRIPTION
Fixes: https://concourse.cloud-platform.service.justice.gov.uk/teams/main/pipelines/maintenance/jobs/update-authorized-keys/builds/283.

Although the pipeline raised the PR, the output message was not parsed properly and throw "`[]': no implicit conversion of Symbol into Integer"