### PR TITLE
Fix username ONLY for kops

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+
+repos:
+- repo: git://github.com/antonbabenko/pre-commit-terraform
+  rev: v1.48.0
+  hooks:
+    - id: terraform_fmt
+    - id: terraform_docs
+    - id: terraform_tflint
+    - id: terraform_tfsec

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,5 +5,6 @@ repos:
   hooks:
     - id: terraform_fmt
     - id: terraform_docs
+      args: ['--args=--sort-by-required --hide modules']
     - id: terraform_tflint
     - id: terraform_tfsec

--- a/README.md
+++ b/README.md
@@ -14,17 +14,56 @@ module "bastion" {
 }
 ```
 
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| terraform | >= 0.13 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| aws | n/a |
+| template | n/a |
+| tls | n/a |
+
+## Resources
+
+| Name |
+|------|
+| [aws_ami](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) |
+| [aws_autoscaling_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) |
+| [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
+| [aws_eip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/eip) |
+| [aws_iam_instance_profile](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) |
+| [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
+| [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
+| [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
+| [aws_key_pair](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/key_pair) |
+| [aws_launch_configuration](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_configuration) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
+| [aws_route53_record](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) |
+| [aws_route53_zone](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) |
+| [aws_security_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) |
+| [aws_subnet_ids](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet_ids) |
+| [aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) |
+| [template_cloudinit_config](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/cloudinit_config) |
+| [template_file](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) |
+| [tls_private_key](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|:----:|:-----:|:-----:|
-| vpc_name | The VPC where bastion is going to be deployed | string |  | yes |
-| route53_zone | The DNS hostzone where bastion is going to be created, usually is going to be something like bastion.$clusterName.cloud-platform.service.justice.gov.uk. | string | | yes |
-| key_name | The key_pair name to be used in the bastion instance | string | | yes |
+|------|-------------|------|---------|:--------:|
+| cluster\_domain\_name | Domain name is used to generate key\_pair name to be used in the bastion instance | `string` | n/a | yes |
+| route53\_zone | The DNS hostzone where bastion is going to be created, usually is going to be something like bastion.$clusterName.cloud-platform.service.justice.gov.uk. | `string` | n/a | yes |
+| vpc\_name | The vpc\_name where the security groups and bastions are going to be created | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| bastion_endpoint | Access key id for s3 account |
-| bastion_eip | Arn for s3 bucket created |
+| authorized\_keys\_for\_kops | authorized\_keys rendered template used by kops |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/main.tf
+++ b/main.tf
@@ -60,6 +60,18 @@ data "template_file" "authorized_keys_manager" {
 
   vars = {
     authorized_keys_url = local.authorized_keys_url
+    username            = "admin"
+  }
+}
+
+data "template_file" "authorized_keys_for_kops" {
+  template = file(
+    "${path.module}/resources/bastion/authorized_keys_manager.service",
+  )
+
+  vars = {
+    authorized_keys_url = local.authorized_keys_url
+    username            = "ubuntu"
   }
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
-output "authorized_keys_manager" {
+output "authorized_keys_for_kops" {
   description = "authorized_keys rendered template used by kops"
-  value       = data.template_file.authorized_keys_manager.rendered
+  value       = data.template_file.authorized_keys_for_kops.rendered
 }

--- a/resources/bastion/authorized_keys_manager.service
+++ b/resources/bastion/authorized_keys_manager.service
@@ -5,7 +5,7 @@ ExecStart=/bin/bash -c '\
   while true; do \
     ak=$(curl -Lfs ${authorized_keys_url}) \
       && [ ! -z "$$ak" ] \
-      && echo "$$ak" > /home/admin/.ssh/authorized_keys; \
+      && echo "$$ak" > /home/${username}/.ssh/authorized_keys; \
     sleep 60; \
   done;'
 [Install]


### PR DESCRIPTION
With the Kubernetes upgrade to 1.18 kops, which changed the host images from Debian to Ubuntu, we don't use the admin host to connect to nodes anymore because it is now Ubuntu (but ONLY for kops)